### PR TITLE
Add support for json extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+Add support for `.template.json` files
+
 ## 0.1.3
 
 Upgrade dependency for `build` to `^1.0.0`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A basic Builder for injecting content into html templates.
+A basic Builder for injecting content into html and json templates.
 
 ## Usage
 
@@ -9,7 +9,7 @@ dev_dependencies:
   built_html: ^0.1.0
 ```
 
-The next step is to rename your `*.html` files to a `*.template.html` files. Those files will be modified and copied to the original `*.html` location.
+The next step is to rename your `*.html` or `*.json` files to a `*.template.html` or `*.template.json` files. Those files will be modified and copied to the original location.
 
 Also, take a look at [example project](example/) for a working solution.
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: built_html_example
 version: 1.0.0
-description: Example to build *.html files from *.template.html source.
+description: Example to build *.html, *json files from *.template.html and *.template.json source.
 
 environment:
   sdk: '>=2.0.0 <3.0.0'

--- a/example/web/assets.template.json
+++ b/example/web/assets.template.json
@@ -1,0 +1,4 @@
+{
+  "js": "{{digest scripts.js}}",
+  "css": "{{digest styles.css}}"
+}

--- a/example/web/scripts.js
+++ b/example/web/scripts.js
@@ -1,0 +1,1 @@
+console.log('usefull script')

--- a/example/web/styles.css
+++ b/example/web/styles.css
@@ -1,0 +1,1 @@
+.body { height: 100%; }

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -11,13 +11,14 @@ HtmlTemplateBuilder htmlBuilder(BuilderOptions options) =>
     HtmlTemplateBuilder();
 
 PostProcessBuilder templateCleanupBuilder(BuilderOptions options) =>
-    FileDeletingBuilder(['.template.html'],
+    FileDeletingBuilder(['.template.html', '.template.json'],
         isEnabled: options.config['enabled'] as bool ?? false);
 
 class HtmlTemplateBuilder extends Builder {
   @override
   final buildExtensions = {
-    '.template.html': ['.html']
+    '.template.html': ['.html'],
+    '.template.json': ['.json']
   };
 
   @override
@@ -93,7 +94,7 @@ Expected a command followed by a value, like {{command value}}.
     output.write(content.substring(lastEnd, content.length));
 
     await buildStep.writeAsString(
-      buildStep.inputId.changeExtension('').changeExtension('.html'),
+      buildStep.inputId.changeExtension('').changeExtension(buildStep.inputId.extension),
       output.toString(),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: built_html
-version: 0.1.3
+version: 0.1.4
 author: Jacob MacDonald <jakemac53@gmail.com>
-description: A Builder for injecting content hashes into html templates
+description: A Builder for injecting content hashes into html templates or json files
 homepage: https://github.com/jakemac53/built_html
 
 environment:

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -6,13 +6,13 @@ import 'package:test/test.dart';
 main() {
   test('Digest command works', () async {
     await testBuilder(HtmlTemplateBuilder(), {
-      'a|index.template.html': '''
-<p>{{digest index.template.html}}</p>
-''',
+      'a|index.template.html': '<p>{{digest index.template.html}}</p>',
+      'a|script.js': 'useful js script',
+      'a|styles.css': 'useful css styles',
+      'a|assets.template.json': '{ "script.js": "{{digest script.js}}", "styles.css": "{{digest styles.css}}" }',
     }, outputs: {
-      'a|index.html': '''
-<p>9e43ec54624795b34b4dd9ee60ffe652</p>
-''',
+      'a|index.html': '<p>ddfbfb428acba99177a5d34f795f24d9</p>',
+      'a|assets.json': '{ "script.js": "5140897c4b2dd3628459f33e0df969e2", "styles.css": "d5e95fc0e4382d6f22d3b4103594da79" }'
     });
   });
 }


### PR DESCRIPTION
Hi, thanks for the library.

This PR adds ability to inject digests in json files. It allows user to generate an assets map and use it as a centralised container of all digests(this is my usecase). I know that it's not exactly aligned with the library name, but I thought it could be a good addition. 